### PR TITLE
ItemManagerクラスをphpcs通した。

### DIFF
--- a/applications/ItemManager.php
+++ b/applications/ItemManager.php
@@ -34,7 +34,7 @@ class ItemManager
      *
      * @return array 商品情報
      */
-    public function get_items()
+    public function getItems()
     {
         return $this->items;
     }

--- a/applications/Seller.php
+++ b/applications/Seller.php
@@ -34,7 +34,7 @@ class Seller
      */
     public function find_items($amount)
     {
-        $items = $this->ItemManager->get_items();
+        $items = $this->ItemManager->getItems();
 
         $find_items = array();
         foreach ($items as $item) {
@@ -56,7 +56,7 @@ class Seller
      */
     public function is_buyable($name, $amount)
     {
-        $items = $this->ItemManager->get_items();
+        $items = $this->ItemManager->getItems();
         foreach ($items as $item) {
             if ($item["name"] == $name) {
                 $buy_item = $item;

--- a/tests/ItemManagerTest.php
+++ b/tests/ItemManagerTest.php
@@ -1,15 +1,11 @@
 <?php
+namespace MerryMurakami\VendingMachine\Test;
 
-/**
- * Created by PhpStorm.
- * User: nokablank
- * Date: 15/07/17
- * Time: 20:36
- */
-require_once(dirname(__FILE__) . '/../applications/config/autoload.php');
 use MerryMurakami\VendingMachine\ItemManager;
 
-class ItemManagerTest extends PHPUnit_Framework_TestCase
+require_once(dirname(__FILE__) . '/../applications/config/autoload.php');
+
+class ItemManagerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var ItemManager
@@ -44,7 +40,7 @@ class ItemManagerTest extends PHPUnit_Framework_TestCase
             ]
         ];
 
-        $expected = $this->itemManager->get_items();
+        $expected = $this->itemManager->getItems();
         $this->assertArraySubset($item, $expected);
     }
 }


### PR DESCRIPTION
- PSR2に従いメソッド名を修正。
- テストコードにもnamespace使った。
- PHPUnitのスーパークラスはルートの名前空間でextendsしなければならなくなった。
