### PR TITLE
Preserve.phpのis_usableをキャメル記法に修正

### DIFF
--- a/applications/Preserve.php
+++ b/applications/Preserve.php
@@ -30,7 +30,7 @@ class Preserve
      *
      * @return int 加えることができなかったお金
      */
-    function add_amount($money)
+    public function addAmount($money)
     {
         $is_usable = $this->coinMech->isUsable($money);
         if ($is_usable === false) {
@@ -47,7 +47,7 @@ class Preserve
      *
      * @return int 総額
      */
-    function take_out_amount()
+    public function takeoutAmount()
     {
         $amount_all = $this->amount;
         $this->amount = 0;
@@ -60,7 +60,7 @@ class Preserve
      *
      * @return int 総額
      */
-    function get_amount()
+    public function getAmount()
     {
         return $this->amount;
     }

--- a/applications/VendingMachine.php
+++ b/applications/VendingMachine.php
@@ -31,7 +31,7 @@ class VendingMachine
      */
     function get_amount()
     {
-        return $this->preserve->get_amount();
+        return $this->preserve->getAmount();
     }
 
     /**
@@ -43,7 +43,7 @@ class VendingMachine
      */
     function add_amount($money)
     {
-        return $this->preserve->add_amount($money);
+        return $this->preserve->addAmount($money);
     }
 
     /**
@@ -53,7 +53,7 @@ class VendingMachine
      */
     function pay_back()
     {
-        return $this->preserve->take_out_amount();
+        return $this->preserve->takeoutAmount();
     }
 
     /**

--- a/tests/PreserveTest.php
+++ b/tests/PreserveTest.php
@@ -31,7 +31,7 @@ class PreserveTest extends PHPUnit_Framework_TestCase
      */
     public function 総額に加える_正常系($invest, $expected)
     {
-        $result = $this->preserve->add_amount($invest);
+        $result = $this->preserve->addAmount($invest);
         $this->assertEquals($expected, $result);
     }
 
@@ -47,7 +47,7 @@ class PreserveTest extends PHPUnit_Framework_TestCase
      */
     public function 総額に加える_異常系($invest, $expected)
     {
-        $result = $this->preserve->add_amount($invest);
+        $result = $this->preserve->addAmount($invest);
         $this->assertEquals($expected, $result);
     }
 
@@ -64,9 +64,9 @@ class PreserveTest extends PHPUnit_Framework_TestCase
     public function 総額を取り出す_正常系($invests, $expected)
     {
         foreach ($invests as $invest) {
-            $this->preserve->add_amount($invest);
+            $this->preserve->addAmount($invest);
         }
-        $result = $this->preserve->take_out_amount();
+        $result = $this->preserve->takeoutAmount();
         $this->assertEquals($expected, $result);
     }
 
@@ -83,8 +83,8 @@ class PreserveTest extends PHPUnit_Framework_TestCase
     public function 総額を教える_正常系($invests, $expected)
     {
         for ($i = 0; $i < count($invests); $i++) {
-            $this->preserve->add_amount($invests[$i]);
-            $result = $this->preserve->get_amount();
+            $this->preserve->addAmount($invests[$i]);
+            $result = $this->preserve->getAmount();
             $this->assertEquals($expected[$i], $result);
         }
     }


### PR DESCRIPTION
PSR2対応
