### PR TITLE
VendingMachineTest.phpのテストコードの変数名とコメントを修正

### DIFF
--- a/applications/VendingMachine.php
+++ b/applications/VendingMachine.php
@@ -63,6 +63,6 @@ class VendingMachine
      */
     public function getJuiceInfo()
     {
-        return $this->itemManager->get_items();
+        return $this->itemManager->getItems();
     }
 }

--- a/tests/VendingMachineTest.php
+++ b/tests/VendingMachineTest.php
@@ -99,6 +99,35 @@ class VendingMachineTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @test
+     *
+     * @return void
+     */
+    public function コーラとレッドブルと水があるか()
+    {
+        $item = [
+            [
+                "name"  => "コーラ",
+                "price" => 120,
+                "stock" => 5
+            ],
+            [
+                "name"  => "レッドブル",
+                "price" => 200,
+                "stock" => 5
+            ],
+            [
+                "name"  => "水",
+                "price" => 100,
+                "stock" => 5
+            ]
+        ];
+
+        $expected = $this->vendingMachine->getJuiceInfo();
+        $this->assertArraySubset($item, $expected);
+    }
+
+    /**
      * データプロバイダ
      * 総額に加える
      *

--- a/tests/VendingMachineTest.php
+++ b/tests/VendingMachineTest.php
@@ -7,7 +7,10 @@ require_once(dirname(__FILE__) . '/../applications/config/autoload.php');
 
 class VendingMachineTest extends \PHPUnit_Framework_TestCase
 {
-    private $vendingMachine_obj;
+    /**
+     * @var VendingMachine
+     */
+    private $vendingMachine;
 
     /**
      * 毎テスト開始時の初期化関数
@@ -16,38 +19,38 @@ class VendingMachineTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->vendingMachine_obj = new VendingMachine();
+        $this->vendingMachine = new VendingMachine();
     }
 
     /**
      * @test
      *
-     * @param array $invests  投入されるお金
+     * @param int   $invest   投入されるお金
      * @param int   $expected 受け取れなかった金額
      *
      * @return void
      *
      * @dataProvider お金受け取る_正常系Provider
      */
-    public function お金受け取る_正常系($invests, $expected)
+    public function お金受け取る_正常系($invest, $expected)
     {
-        $result = $this->vendingMachine_obj->addAmount($invests);
+        $result = $this->vendingMachine->addAmount($invest);
         $this->assertEquals($expected, $result);
     }
 
     /**
      * @test
      *
-     * @param array $invests  投入されるお金
+     * @param int   $invest   投入されるお金
      * @param int   $expected 受け取れなかった金額
      *
      * @return void
      *
      * @dataProvider お金受け取る_異常系Provider
      */
-    public function お金受け取る_異常系($invests, $expected)
+    public function お金受け取る_異常系($invest, $expected)
     {
-        $result = $this->vendingMachine_obj->addAmount($invests);
+        $result = $this->vendingMachine->addAmount($invest);
         $this->assertEquals($expected, $result);
     }
 
@@ -63,10 +66,11 @@ class VendingMachineTest extends \PHPUnit_Framework_TestCase
      */
     public function 総額表示_正常系($invests, $expected)
     {
-        foreach ($invests as $money) {
-            $this->vendingMachine_obj->addAmount($money);
+        foreach ($invests as $money)
+        {
+            $this->vendingMachine->addAmount($money);
         }
-        $result = $this->vendingMachine_obj->getAmount();
+        $result = $this->vendingMachine->getAmount();
         $this->assertEquals($expected, $result);
     }
 
@@ -82,14 +86,15 @@ class VendingMachineTest extends \PHPUnit_Framework_TestCase
      */
     public function 払い出す_正常系($invests, $expected)
     {
-        foreach ($invests as $money) {
-            $this->vendingMachine_obj->addAmount($money);
+        foreach ($invests as $money)
+        {
+            $this->vendingMachine->addAmount($money);
         }
         // 投入された分だけの数を払い出すか
-        $result = $this->vendingMachine_obj->payBack();
+        $result = $this->vendingMachine->payBack();
         $this->assertEquals($expected, $result);
         // 払い出した後は0になっているか
-        $zero = $this->vendingMachine_obj->getAmount();
+        $zero = $this->vendingMachine->getAmount();
         $this->assertEquals(0, $zero);
     }
 


### PR DESCRIPTION
変数名の_objをやめた。
VendingMachineの変数にタイプヒントを追加した。
テストコードのコメントの方が間違ってたので修正した。arrayからintへ。
